### PR TITLE
fix dobby_ui build for making containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is an Erlang node that contains:
 1. [dobby_core_lib](https://github.com/ivanos/dobby_core_lib)
 2. [dobby_rest_lib](https://github.com/ivanos/dobby_rest_lib)
 3. [dobby_ui_lib](https://github.com/ivanos/dobby_ui_lib)
-1. [lucet_core_lib](https://github.com/ivanos/lucet)
+1. [lucet_core_lib](https://github.com/ivanos/lucet_core_lib)
 1. [leviathan_lib](https://github.com/ivanos/leviathan_lib)
 
 <!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc/generate-toc again -->

--- a/rebar.config
+++ b/rebar.config
@@ -26,6 +26,6 @@
 {pre_hooks, [{'get-deps', "sh -c 'npm --version >> /dev/null"
               " || (echo \"npm not installed\"; exit 1)'"}]}.
 
-{post_hooks, [{'get-deps', "sh -c 'cd deps/dobby_ui && npm install && cd -'"},
+{post_hooks, [{'get-deps', "sh -c 'cd deps/dobby_ui && npm install --unsafe-perm && cd -'"},
               {compile,
                "sh -c 'cp -r deps/dobby_ui/www deps/dobby_rest/priv/static'"}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
   {dobby_rest,  ".*", {git, "https://github.com/ivanos/dobby_rest_lib.git",
                        {branch,"master"}}},
   {dobby_ui, "", {git, "https://github.com/ivanos/dobby_ui_lib.git",
-                  {branch, "master"}}, [raw]},
+                  {branch, "devel"}}, [raw]},
   {lucet, "", {git, "https://github.com/ivanos/lucet_core_lib.git",
                {branch, "master"}}},
   {leviathan_lib, "", {git, "https://github.com/ivanos/leviathan_lib.git",

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
   {dobby_rest,  ".*", {git, "https://github.com/ivanos/dobby_rest_lib.git",
                        {branch,"master"}}},
   {dobby_ui, "", {git, "https://github.com/ivanos/dobby_ui_lib.git",
-                  {branch, "devel"}}, [raw]},
+                  {branch, "master"}}, [raw]},
   {lucet, "", {git, "https://github.com/ivanos/lucet_core_lib.git",
                {branch, "master"}}},
   {leviathan_lib, "", {git, "https://github.com/ivanos/leviathan_lib.git",


### PR DESCRIPTION
Creating containers runs as root requiring additional flags on npm install.

Fix a link in the README.
