### PR TITLE
Add FSMs for CENs and CINs; introduce executive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-.PHONY: all compile get-deps update-deps clean deep-clean rel
+.PHONY: all compile dev_compile dev_compile2 get-deps update-deps \
+	clean deep-clean rel proper
 
 all: rebar rel
 
 compile: get-deps
 	./rebar compile
+
+dev_compile: deep-clean get-deps
+	LEV_DEV=true $(MAKE) dev_compile2
+
+dev_compile2:
+	./rebar compile -D TEST apps=lager,lucet,leviathan_lib,leviathan
+	./rebar compile
+
 
 get-deps:
 	./rebar get-deps
@@ -11,11 +20,24 @@ get-deps:
 update-deps:
 	./rebar update-deps
 
+proper: dev_compile no_compile_proper
+
+no_compile_proper: 
+	rm -rf Mnesia.prop_test@*
+	erl -pa ebin deps/*/ebin \
+	-noshell \
+	-sname prop_test -erl_mnesia options \[persistent\] \
+	-eval "R = [begin \
+		{_, [M]}=re:run(P, \".*/(?<m>.*).beam\", [{capture, ['m'], list}]), \
+		proper:module(list_to_atom(M)) end || P <- filelib:wildcard(\"ebin/prop_*\")], \
+		R == [] andalso io:format(\"No properties to run.~n\")" \
+	 -s init stop
+
 clean:
 	./rebar clean
 
 deep-clean: clean
-	rm -rf deps/*/ebin/*
+	rm -f deps/*/ebin/*
 
 rel: compile id_rsa
 	./relx -c _rel/relx.config

--- a/config/sys.config
+++ b/config/sys.config
@@ -8,6 +8,9 @@
                   %% uncomment the line below for testing purposes
                   %% {docker_bin, "cat"}
                  ]},
+ {leviathan_rest, [
+                   {callback_module, lev_executive}
+                  ]},
  {erl_sshd, [
              {app, leviathan},
              {port, 11155},

--- a/config/sys.config.template
+++ b/config/sys.config.template
@@ -9,6 +9,9 @@
                   %% {docker_bin, "cat"},
                   {tunnel_user, {{tunnel_user}}}
                  ]},
+ {leviathan_rest, [
+                   {callback_module, lev_executive}
+                  ]},
  {erl_sshd, [
              {app, leviathan},
              {port, 11155},

--- a/rebar.config
+++ b/rebar.config
@@ -9,11 +9,11 @@
   {lager_websocket, ".*", {git, "https://github.com/ivanos/lager_websocket.git",
                  {branch,"master"}}},
   {dobby, ".*", {git, "https://github.com/ivanos/dobby_core_lib.git",
-                 {branch,"master"}}},
+                 {branch,"subscription_bug"}}},
   {lucet, "", {git, "https://github.com/ivanos/lucet_core_lib.git",
                {branch, "master"}}},
   {dobby_oflib, ".", {git, "https://github.com/ivanos/dobby_oflib.git",
-                      {tag, "multi-host-demo"}}},
+                      {branch, "multi-host"}}},
   {weave, "", {git, "https://github.com/ivanos/weave_core_lib.git",
                {branch, "master"}}},
   {dobby_rest,  ".*", {git, "https://github.com/ivanos/dobby_rest_lib.git",
@@ -25,9 +25,9 @@
   {ivanos_ui, "", {git, "https://github.com/ivanos/ivanos_ui_lib.git",
                   {branch, "master"}}, [raw]},
   {leviathan_lib, "", {git, "https://github.com/ivanos/leviathan_lib.git",
-              {tag, "multi-host-demo"}}},
+              {branch, "multi-host"}}},
   {leviathan_rest, "", {git, "https://github.com/ivanos/leviathan_rest_lib.git",
-                        {tag, "multi-host-demo"}}}]
+                        {branch, "multi-host"}}}]
  }.
 
 {erl_opts, [fail_on_warning,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,12 @@
+case os:getenv("LEV_DEV") of
+    false ->
+        CONFIG;
+    _ ->
+        CompileTests = [
+                        {src_dirs, ["src", "test"]},
+                        {i, "src/"}
+                       ],
+        {erl_opts, ErlOpts} = lists:keyfind(erl_opts, 1, CONFIG),
+        lists:keystore(erl_opts, 1, CONFIG,
+                       {erl_opts, ErlOpts ++ CompileTests})
+end.

--- a/src/lev_cen_fsm.erl
+++ b/src/lev_cen_fsm.erl
@@ -1,0 +1,111 @@
+-module(lev_cen_fsm).
+-behaviour(gen_fsm).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([start_link/2]).
+
+%% ------------------------------------------------------------------
+%% gen_fsm Function Exports
+%% ------------------------------------------------------------------
+
+-export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
+         terminate/3, code_change/4]).
+
+%% CEN Statuses
+-export([importing/2, pending/2, preparing/2, ready/2, destroying/2]).
+
+%% ------------------------------------------------------------------
+%% Types & Records & Macros & Includes
+%% ------------------------------------------------------------------
+
+-type cen_id() :: string().
+-type host_id() :: string().
+
+-record(state, {id :: cen_id(),
+                host_id ::  host_id(),
+                subscription :: subscription_id()}).
+
+-define(SERVER, self()).
+-define(INIT_CEN_STATUS, <<"importing">>).
+
+-include_lib("dobby_clib/include/dobby.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link(CenId, HostId) ->
+    gen_fsm:start_link(?MODULE, [CenId, HostId], []).
+
+
+%% ------------------------------------------------------------------
+%% gen_fsm Function Definitions
+%% ------------------------------------------------------------------
+
+init([CenId, HostId]) ->
+    DeliveryFn = delivery_fun(status_change),
+    SubId = make_subscription(CenId, ?INIT_CEN_STATUS, DeliveryFn),
+    State = #state{id = CenId, host_id = HostId, subscription = SubId},
+    send_cen_message(imported, State),
+    {ok, importing, State}.
+     
+
+importing({status_change, <<"pending">>}, State) ->
+    {next_state, pending, State}.
+    
+pending({status_change, <<"preparing">>}, State) ->
+    leviathan_cen:prepare([State#state.id]),
+    send_cen_message(prepared, State),
+    {next_state, preparing, State}.
+
+preparing({status_change, <<"ready">>}, State) ->
+    {next_state, ready, State}.
+
+ready({status_change, <<"destroying">>}, State) ->
+    leviathan_cen:destroy([State#state.id]),
+    send_cen_message(destroyed, State),
+    {next_state, destroying, State}.
+
+destroying({status_change, <<"pending">>}, State) ->
+    {next_state, pending, State}.
+
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    Reply = ok,
+    {reply, Reply, StateName, State}.
+
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, #state{subscription = SubId}) ->
+    leviathan_dby:unsubscribe(SubId),
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+make_subscription(CenId, CurrentStatus, DeliveryFn) ->
+    {CurrentStatus, SubId} =
+        leviathan_dby:subscribe_for_cen_status_change(CenId,
+                                                      DeliveryFn),
+    SubId.
+
+send_cen_message(Type, #state{id = CenId, host_id = HostId}) ->
+    leviathan_dby:send_cen_message(CenId, {Type, {CenId, HostId}}).
+
+delivery_fun(Event) ->
+    FsmRef = ?SERVER,
+    fun(Status) ->
+            gen_fsm:send_event(FsmRef, {Event, Status})
+    end.
+    

--- a/src/lev_cen_sup.erl
+++ b/src/lev_cen_sup.erl
@@ -1,15 +1,15 @@
--module(leviathan_sup).
+-module(lev_cen_sup).
 
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, add_cen_fsm/2]).
 
 %% Supervisor callbacks
 -export([init/1]).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+-define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% ===================================================================
 %% API functions
@@ -18,15 +18,16 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+add_cen_fsm(Node, Options) ->
+    supervisor:start_child({?MODULE, Node}, Options).
+
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
 init([]) ->
-    Children = [
-                ?CHILD(lev_executive, worker),
-                ?CHILD(lev_cen_sup, supervisor),
-                ?CHILD(lev_cin_sup, supervisor)
-               ],
-    {ok, { {one_for_one, 5, 10}, Children} }.
+    {ok, {
+       {simple_one_for_one, 5, 10},
+       [?CHILD(lev_cen_fsm, worker, [])]
+      }}.
 

--- a/src/lev_cin_fsm.erl
+++ b/src/lev_cin_fsm.erl
@@ -1,0 +1,118 @@
+-module(lev_cin_fsm).
+-behaviour(gen_fsm).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+
+-export([start_link/3, stop/1]).
+
+%% ------------------------------------------------------------------
+%% gen_fsm Function Exports
+%% ------------------------------------------------------------------
+
+-export([init/1, handle_event/3, handle_sync_event/4, handle_info/3,
+         terminate/3, code_change/4]).
+
+%% CIN Statuses
+-export([importing/2, pending/2, preparing/2, ready/2, destroying/2]).
+
+%% ------------------------------------------------------------------
+%% Types & Records & Macros & Includes
+%% ------------------------------------------------------------------
+
+
+
+-record(cin_fsm_state, {id :: cin_id(),
+                        cen_ids :: [cen_id()],
+                        host_id ::  host_id(),
+                        subscription :: subscription_id()}).
+
+-define(SERVER, self()).
+-define(INIT_CIN_STATUS, <<"importing">>).
+-define(STATE, cin_fsm_state).
+
+-include("leviathan.hrl").
+-include_lib("dobby_clib/include/dobby.hrl").
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link(CinId, HostId, CinIds) ->
+    gen_fsm:start_link(?MODULE, [CinId, HostId, CinIds], []).
+
+stop(FsmRef) ->
+    gen_fsm:stop(FsmRef).
+
+
+%% ------------------------------------------------------------------
+%% gen_fsm Function Definitions
+%% ------------------------------------------------------------------
+
+init([CinId, HostId, CinIds]) ->
+    DeliveryFn = delivery_fun(status_change),
+    SubId = make_subscription(CinId, ?INIT_CIN_STATUS, DeliveryFn),
+    State = #?STATE{id = CinId,
+                    host_id = HostId,
+                    cen_ids = CinIds,
+                    subscription = SubId},
+    send_cin_message(imported, State),
+    {ok, importing, State}.
+     
+
+importing({status_change, <<"pending">>}, State) ->
+    {next_state, pending, State}.
+    
+pending({status_change, <<"preparing">>}, State) ->
+    leviathan_cin:prepare([State#?STATE.id]),
+    send_cin_message(prepared, State),
+    {next_state, preparing, State}.
+
+preparing({status_change, <<"ready">>}, State) ->
+    {next_state, ready, State}.
+
+ready({status_change, <<"destroying">>}, State) ->
+    leviathan_cin:destroy([State#?STATE.id]),
+    send_cin_message(destroyed, State),
+    {next_state, destroying, State}.
+
+destroying({status_change, <<"pending">>}, State) ->
+    {next_state, pending, State}.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    Reply = ok,
+    {reply, Reply, StateName, State}.
+
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, #?STATE{subscription = SubId}) ->
+    leviathan_dby:unsubscribe(SubId),
+    ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+make_subscription(CinId, CurrentStatus, DeliveryFn) ->
+    {CurrentStatus, SubId} =
+        leviathan_dby:subscribe_for_cin_status_change(CinId,
+                                                      DeliveryFn),
+    SubId.
+
+send_cin_message(Type, #?STATE{id = CinId, host_id = HostId}) ->
+    leviathan_dby:send_cin_message(CinId, {Type, {CinId, HostId}}).
+
+delivery_fun(Event) ->
+    FsmRef = ?SERVER,
+    fun(Status) ->
+            gen_fsm:send_event(FsmRef, {Event, Status})
+    end.
+    

--- a/src/lev_cin_sup.erl
+++ b/src/lev_cin_sup.erl
@@ -1,15 +1,15 @@
--module(leviathan_sup).
+-module(lev_cin_sup).
 
 -behaviour(supervisor).
 
 %% API
--export([start_link/0]).
+-export([start_link/0, add_cin_fsm/2]).
 
 %% Supervisor callbacks
 -export([init/1]).
 
 %% Helper macro for declaring children of supervisor
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, 5000, Type, [I]}).
+-define(CHILD(I, Type, Args), {I, {I, start_link, Args}, permanent, 5000, Type, [I]}).
 
 %% ===================================================================
 %% API functions
@@ -18,15 +18,16 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+add_cin_fsm(Node, Options) ->
+    supervisor:start_child({?MODULE, Node}, Options).
+
 %% ===================================================================
 %% Supervisor callbacks
 %% ===================================================================
 
 init([]) ->
-    Children = [
-                ?CHILD(lev_executive, worker),
-                ?CHILD(lev_cen_sup, supervisor),
-                ?CHILD(lev_cin_sup, supervisor)
-               ],
-    {ok, { {one_for_one, 5, 10}, Children} }.
+    {ok, {
+       {simple_one_for_one, 5, 10},
+       [?CHILD(lev_cin_fsm, worker, [])]
+      }}.
 

--- a/src/lev_executive.erl
+++ b/src/lev_executive.erl
@@ -1,6 +1,5 @@
 -module(lev_executive).
--behaviour(gen_server).
--define(SERVER, ?MODULE).
+-behaviour(gen_fsm).
 
 %% ------------------------------------------------------------------
 %% API Function Exports
@@ -8,51 +7,390 @@
 
 -export([start_link/0]).
 
+%% CENs API
+-export([import_cens/1, make_cens/1, destroy_cens/1]).
+%% CINs API
+-export([import_cins/1, make_cins/1, destroy_cins/1]).
+
 %% ------------------------------------------------------------------
-%% gen_server Function Exports
+%% gen_fsm Function Exports
 %% ------------------------------------------------------------------
 
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+-export([init/1, idle/3, handle_event/3, handle_sync_event/4,
+         handle_info/3, terminate/3, code_change/4]).
 
+%% CEN states
+-export([cen_import/2, cen_prepare/2, cen_destroy/2]).
+%% CIN states
+-export([cin_import/2, cin_prepare/2, cin_destroy/2]).
+
+
+%% ------------------------------------------------------------------
+%% Types & Records & Macros & Includes
+%% ------------------------------------------------------------------
+
+-type cen_id() :: string().
+-type host_id() :: string().
+
+-record(state, {
+          host_to_node :: #{host_id() => node()},
+          subscriptions :: #{cen_id() =>
+                                 {[host_id()], subscription_id()}},
+          reply_to :: pid()}).
+
+-define(SERVER, ?MODULE).
+
+-include_lib("dobby_clib/include/dobby.hrl").
+-include_lib("kernel/include/inet.hrl").
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
 
 start_link() ->
-    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+    gen_fsm:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+import_cens(JsonBin) ->
+    gen_fsm:sync_send_event(?SERVER, {import_cens, JsonBin}, 10000).
+
+make_cens(CenIds) ->
+    gen_fsm:sync_send_event(?SERVER, {make_cens, CenIds}, 10000).
+
+destroy_cens(CenIds) ->
+    gen_fsm:sync_send_event(?SERVER, {destroy_cens, CenIds}, 10000).
+
+import_cins(CinToCensBin) ->
+    gen_fsm:sync_send_event(?SERVER, {import_cins, CinToCensBin}, 10000).
+
+make_cins(CinIds) ->
+    gen_fsm:sync_send_event(?SERVER, {make_cins, CinIds}, 10000).
+
+destroy_cins(CinIds) ->
+    gen_fsm:sync_send_event(?SERVER, {destroy_cins, CinIds}, 10000).
 
 %% ------------------------------------------------------------------
-%% gen_server Function Definitions
+%% gen_fsm Function Definitions
 %% ------------------------------------------------------------------
 
-init(Args) ->
+init(_) ->
     ok = net_kernel:monitor_nodes(true),
-    {ok, Args}.
+    {ok, idle, #state{host_to_node = host_to_node()}}.
 
-handle_call(_Request, _From, State) ->
-    {reply, ok, State}.
+%% CENs
+idle({import_cens, JsonBin}, From, State) ->
+    gen_fsm:send_event(?SERVER, {import, build_cen_lm(JsonBin)}),
+    {next_state, cen_import, State#state{reply_to = From}};
+idle({make_cens, CenIds}, From, State) ->
+    gen_fsm:send_event(?SERVER, {prepare, CenIds}),
+    {next_state, cen_prepare, State#state{reply_to = From}};
+idle({destroy_cens, CenIds}, From, State) ->
+    gen_fsm:send_event(?SERVER, {destroy, CenIds}),
+    {next_state, cen_destroy, State#state{reply_to = From}};
+%% CINs
+idle({import_cins, CinToCensBin}, From, State) ->
+    gen_fsm:send_event(?SERVER, {import, build_cin_lm(CinToCensBin)}),
+    {next_state, cin_import, State#state{reply_to = From}};
+idle({make_cins, CenIds}, From, State) ->
+    gen_fsm:send_event(?SERVER, {prepare, CenIds}),
+    {next_state, cin_prepare, State#state{reply_to = From}};
+idle({destroy_cins, CenIds}, From, State) ->
+    gen_fsm:send_event(?SERVER, {destroy, CenIds}),
+    {next_state, cin_destroy, State#state{reply_to = From}};
+%% Unimplemented
+idle(_, _From, State) ->
+    {reply, not_implemented, idle, State}.
 
-handle_cast(_Msg, State) ->
-    {noreply, State}.
+cen_import({import, CenLM}, State) ->
+    import_cens_into_dobby(CenLM),
+    import_cens_into_cluster_stores(CenLM),
+    CenToHost = cen_to_host_map(CenLM),
+    Subs = make_cen_subscriptions(CenToHost,
+                                  delivery_fun(imported),
+                                  cen_done_fun(pending)),
+    start_cens_fsms(CenToHost, State#state.host_to_node),
+    {next_state, cen_import, State#state{subscriptions = Subs}};
+cen_import({imported, Key}, State) ->
+    case handle_subscription_event(Key, State) of
+        {finished, NewState} ->
+            lager:info("cen_import: CENs imported"),
+            {next_state, idle,  NewState};
+        {continue, NewState} ->
+            {next_state, cen_import, NewState}
+    end.
 
-handle_info({nodeup, Node}, State) ->
-    lager:info("Node ~p connected~n", [Node]),
-    {noreply, State};
-handle_info({nodedown, Node}, State) ->
-    lager:info("Node ~p disconnected~n", [Node]),
-    {noreply, State};
-handle_info(_Info, State) ->
-    {noreply, State}.
+cen_prepare({prepare, CenIds}, State) ->
+    CenToHost = cen_to_host_map(CenIds),
+    Subs = make_cen_subscriptions(CenToHost,
+                                  delivery_fun(prepared),
+                                  cen_done_fun(ready)),
+    set_cens_status(CenIds, preparing),
+    {next_state, cen_prepare, State#state{subscriptions = Subs}};
+cen_prepare({prepared, Key}, State) ->
+    case handle_subscription_event(Key, State) of
+        {finished, NewState} ->
+            lager:info("cen_prepare: CENs prepared"),
+            {next_state, idle, NewState};
+        {continue, NewState} ->
+            {next_state, cen_prepare, NewState}
+    end.
 
-terminate(_Reason, _State) ->
-    ok.
+cen_destroy({destroy, CenIds}, State) ->
+    CenToHost = cen_to_host_map(CenIds),
+    Subs = make_cen_subscriptions(CenToHost,
+                                  delivery_fun(destroyed),
+                                  cen_done_fun(pending)),
+    set_cens_status(CenIds, destroying),
+    {next_state, cen_destroy, State#state{subscriptions = Subs}};
+cen_destroy({destroyed, Key}, State) ->
+    case handle_subscription_event(Key, State) of
+        {finished, NewState} ->
+            lager:info("cen_destroy: CENs destroyed"),
+            {next_state, idle, NewState};
+        {continue, NewState} ->
+            {next_state, cen_destroy, NewState}
+    end.
 
-code_change(_OldVsn, State, _Extra) ->
+cin_import({import, CinLM}, State) ->
+    import_cins_into_dobby(CinLM),
+    import_cins_into_cluster_stores(CinLM),
+    CinToHost = cin_to_host_map(CinLM),
+    CinToCen = cin_to_cen_map(CinLM),
+    Subs = make_cin_subscriptions(CinToHost,
+                                  delivery_fun(imported),
+                                  cin_done_fun(pending)),
+    start_cins_fsms(CinToHost, CinToCen, State#state.host_to_node),
+    {next_state, cin_import, State#state{subscriptions = Subs}};
+cin_import({imported, Key}, State) ->
+    case handle_subscription_event(Key, State) of
+        {finished, NewState} ->
+            lager:info("cin_import: CINs imported"),
+            {next_state, idle, NewState};
+        {continue, NewState} ->
+            {next_state, cin_import, NewState}
+    end.
+
+cin_prepare({prepare, CinIds}, State) ->
+    CinToHost = cin_to_host_map(CinIds),
+    Subs = make_cin_subscriptions(CinToHost,
+                                  delivery_fun(prepared),
+                                  cin_done_fun(ready)),
+    set_cins_status(CinIds, preparing),
+    {next_state, cin_prepare, State#state{subscriptions = Subs}};
+cin_prepare({prepared, Key}, State) ->
+    case handle_subscription_event(Key, State) of
+        {finished, NewState} ->
+            lager:info("cin_prepare: CINs prepared"),
+            {next_state, idle, NewState};
+        {continue, NewState} ->
+            {next_state, cin_prepare, NewState}
+    end.
+
+cin_destroy({destroy, CinIds}, State) ->
+    CinToHost = cin_to_host_map(CinIds),
+    Subs = make_cin_subscriptions(CinToHost,
+                                  delivery_fun(destroyed),
+                                  cin_done_fun(pending)),
+    set_cins_status(CinIds, destroying),
+    {next_state, cin_destroy, State#state{subscriptions = Subs}};
+cin_destroy({destroyed, Key}, State) ->
+    case handle_subscription_event(Key, State) of
+        {finished, NewState} ->
+            lager:info("cin_destroy: CINs destroyed"),
+            {next_state, idle, NewState};
+        {continue, NewState} ->
+            {next_state, cin_destroy, NewState}
+    end.
+
+handle_event(_Event, StateName, State) ->
+    {next_state, StateName, State}.
+
+handle_sync_event(_Event, _From, StateName, State) ->
+    Reply = ok,
+    {reply, Reply, StateName, State}.
+
+handle_info({NodeUpOrDown, Node}, StateName, State) ->
+    lager:info("~p: ~p~n", [Node, NodeUpOrDown]),
+    {next_state, StateName, State#state{host_to_node = host_to_node()}};
+handle_info(_Info, StateName, State) ->
+    {next_state, StateName, State}.
+
+terminate(_Reason, _StateName, #state{subscriptions = Subs}) ->
+    maps:fold(
+      fun(_CenId, HostToSub, _) ->
+              [leviathan_dby:unsubscribe(S)
+               || S <- maps:values(HostToSub)]
+      end, undefined, Subs),
+    net_kernel:monitor_nodes(false).
+
+code_change(_OldVsn, _StateName, State, _Extra) ->
     {ok, State}.
 
 %% ------------------------------------------------------------------
-%% Internal Function Definitions
+%% Internal Function Definitions: CENs
 %% ------------------------------------------------------------------
 
+build_cen_lm(JsonBin) ->
+    leviathan_cen:decode_binary(JsonBin).
+
+import_cens_into_dobby(CenLM) ->
+    ok = leviathan_dby:import_cens(<<"HOST">>, CenLM).
+
+import_cens_into_cluster_stores(CenLM) ->
+    [ok = rpc:call(N, leviathan_cen_store, import_cens,
+                   [<<"HOST">>, CenLM]) || N <- [node() | nodes()]].
+
+%% TODO: CenToHost should be build based on Dobby    
+cen_to_host_map(CenIds) when is_list(CenIds) ->
+    CenLM = leviathan_cen_store:get_levmap(CenIds),
+    leviathan_cen:map_cen_id_to_host(CenLM);
+cen_to_host_map(CenLM) ->
+    leviathan_cen:map_cen_id_to_host(CenLM).
+
+make_cen_subscriptions(CenToHost, DeliveryFn, CenDoneFn) ->
+    maps:fold(
+      fun(CenId, Hosts, Acc) ->
+              Sub = leviathan_dby:subscribe_for_cen_message(
+                      CenId,
+                      DeliveryFn),
+              SubMap = subscription_map(Hosts, Sub, CenDoneFn),
+              maps:put(CenId, SubMap, Acc)
+      end, #{}, CenToHost).
+
+cen_done_fun(NextCenStatus) ->
+    fun(Id) -> set_cens_status([Id], NextCenStatus) end.
+
+%% TODO: CEN FSMs should be started based on occurence of new CEN
+%% identifier in Dobby.
+start_cens_fsms(CenToHost, HostToNode) ->
+    maps:fold(fun(CenId, Hosts, _) ->
+                      start_cen_fsms(CenId, Hosts, HostToNode)
+              end, undefined, CenToHost),
+    ok.
+
+start_cen_fsms(CenId, Hosts, HostToNode) ->
+    lists:foreach(
+      fun(HostId) ->
+              Node = maps:get(HostId, HostToNode),
+              {ok, _}  = lev_cen_sup:add_cen_fsm(Node, [CenId, HostId]),
+              lager:info("{~p, ~p}: waiting", [CenId, Node])
+      end, Hosts).
+
+set_cens_status(CenIds, Status) ->
+    lists:foreach(
+      fun(Id) ->
+              leviathan_dby:set_cen_status(Id, Status)
+      end, CenIds).
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions: CINs
+%% ------------------------------------------------------------------
+
+build_cin_lm(CinsToCensBin) ->
+    leviathan_cin:decode_binary(CinsToCensBin).
+
+import_cins_into_dobby(CinLM) ->
+    ok = leviathan_dby:import_cins(<<"HOST">>, CinLM).
+
+import_cins_into_cluster_stores(CinLM) ->
+    [ok = rpc:call(N, leviathan_cin_store, import_cins,
+                   [<<"HOST">>, CinLM]) || N <- [node() | nodes()]].
+
+%% TODO: CinToHost should be built based on Dobby
+cin_to_host_map(CinIds) when is_list(CinIds) ->
+    CinLM = leviathan_cin_store:get_levmap(CinIds),
+    leviathan_cin:map_cin_id_to_host(CinLM);
+cin_to_host_map(CinLM) ->
+    leviathan_cin:map_cin_id_to_host(CinLM).
+
+%% TODO: CinToCen should be built based on Dobby
+cin_to_cen_map(CinLM) ->
+    leviathan_cin:map_cin_id_to_cen(CinLM).
+
+make_cin_subscriptions(CinToHost, DeliveryFn, CinDoneFn) ->
+    maps:fold(
+      fun(CinId, Hosts, Acc) ->
+              Sub = leviathan_dby:subscribe_for_cin_message(
+                      CinId,
+                      DeliveryFn),
+              SubMap = subscription_map(Hosts, Sub, CinDoneFn),
+              maps:put(CinId, SubMap, Acc)
+      end, #{}, CinToHost).
+
+%% TODO: CIN FSMs should be started based on occurence of new CEN
+%% identifier in Dobby.
+start_cins_fsms(CinToHost, CinToCen, HostToNode) ->
+    maps:fold(fun(CinId, Hosts, _) ->
+                      CenIds = maps:get(CinId, CinToCen),
+                      start_cin_fsms(CinId, Hosts, CenIds, HostToNode)
+              end, undefined, CinToHost),
+    ok.
+
+start_cin_fsms(CinId, Hosts, CenIds, HostToNode) ->
+    lists:foreach(
+      fun(HostId) ->
+              Node = maps:get(HostId, HostToNode),
+              {ok, _}  = lev_cin_sup:add_cin_fsm(Node, [CinId,
+                                                        HostId,
+                                                        CenIds]),
+              lager:info("{~p, ~p}: waiting", [CinId, Node])
+      end, Hosts).
+
+
+set_cins_status(CinIds, Status) ->
+    lists:foreach(
+      fun(Id) ->
+              leviathan_dby:set_cin_status(Id, Status)
+      end, CinIds).
+
+cin_done_fun(NextCenStatus) ->
+    fun(Id) -> set_cins_status([Id], NextCenStatus) end.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions: Other
+%% ------------------------------------------------------------------
+
+handle_subscription_event(Key, #state{subscriptions = Subs0} = State) ->
+    case  handle_subscription_event2(Key, Subs0) of
+        Subs1 when map_size(Subs1) == 0 ->
+            gen_fsm:reply(State#state.reply_to, ok),
+            {finished,
+             State#state{subscriptions = Subs1, reply_to = undefined}};
+        Subs1 ->
+            {continue, State#state{subscriptions = Subs1}}
+    end.
+
+handle_subscription_event2({CenOrCinId, HostId}, Subs) ->
+    case maps:get(CenOrCinId, Subs) of
+        #{hosts := [HostId], sub_id := SubId, on_finish := FinishFn} ->
+            ok = leviathan_dby:unsubscribe(SubId),
+            FinishFn(CenOrCinId),
+            maps:remove(CenOrCinId, Subs);
+        #{hosts := Hosts0} = SubMap ->
+            Hosts1 = lists:delete(HostId, Hosts0),
+            maps:put(CenOrCinId, maps:put(hosts, Hosts1, SubMap), Subs)
+    end.
+
+
+delivery_fun(Event) ->
+    Node = node(),
+    fun({E, {CenOrCinId, HostId}}) when E =:= Event ->
+            ok = gen_fsm:send_event({?SERVER, Node},
+                                    {E, {CenOrCinId, HostId}});
+       (_) ->
+            ok
+    end.
+
+subscription_map(Hosts, SubId, OnFinishFn) ->
+    #{hosts => Hosts, sub_id => SubId, on_finish => OnFinishFn}.
+
+host_to_node() ->
+    host_to_node([node()| nodes()]).
+
+host_to_node(Nodes) ->
+    L = [begin
+             [_, HostName] = string:tokens(atom_to_list(N), "@"),
+             {ok, #hostent{h_addr_list = Ips}} =
+                 inet:gethostbyname(HostName),
+             [{inet:ntoa(Ip), N} || Ip <- Ips]
+         end || N <- Nodes],
+    maps:from_list(lists:flatten(L)).

--- a/src/leviathan.hrl
+++ b/src/leviathan.hrl
@@ -1,0 +1,3 @@
+-type cen_id() :: string().
+-type cin_id() :: string().
+-type host_id() :: string().

--- a/test/prop_lev_cen_fsm.erl
+++ b/test/prop_lev_cen_fsm.erl
@@ -1,0 +1,36 @@
+-module(prop_lev_cen_fsm).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("dobby_clib/include/dobby.hrl").
+
+
+-define(APPS, [dobby, dobby_clib]).
+
+-type cen_id() :: string().
+-type host_id() :: string().
+
+-record(state, {id :: cen_id(),
+                host_id ::  host_id(),
+                subscription :: subscription_id()}).
+
+%%%===================================================================
+%%% Properties
+%%%===================================================================
+
+%%%===================================================================
+%%% Callbacks
+%%%===================================================================
+
+initial_state() ->
+    importing.
+
+initial_state_data() ->
+    #state{id = "cen_id", host_id = "host_id"}.
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+
+    

--- a/test/prop_lev_cin_fsm.erl
+++ b/test/prop_lev_cin_fsm.erl
@@ -1,0 +1,177 @@
+-module(prop_lev_cin_fsm).
+
+-compile([export_all]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-include("leviathan.hrl").
+
+-define(APPS, [dobby, dobby_clib]).
+-define(SERVER, lev_cin_fsm).
+-define(SUBSCRIBER, subscriber).
+
+-define(STATE, cin_fsm_state).
+-define(CIN_ID, "cin1").
+-define(CEN_IDS, ["cen1", "cen2"]).
+-define(HOST_ID, "192.168.0.101").
+
+-define(CALL(Args), {call, gen_fsm, send_event, [?SERVER | Args]}).
+-define(STATUS_CHANGE(S),   {status_change,
+                             list_to_binary(atom_to_list(S))}).
+
+-record(state, {cin_id :: cin_id(),
+                host_id :: host_id(),
+                cen_ids :: [cen_id()]}).
+
+
+
+%%%===================================================================
+%%% Properties
+%%%===================================================================
+
+prop_lev_cen_fsm_works_fine() ->
+    ?FORALL(
+       Cmds,
+       proper_fsm:commands(?MODULE),
+       ?TRAPEXIT(       
+          begin
+              setup(),
+              register(?SERVER,
+                       element(2, lev_cin_fsm:start_link(?CIN_ID,
+                                                         ?HOST_ID,
+                                                         ?CEN_IDS))),
+              {History, State, Result} = proper_fsm:run_commands(?MODULE,
+                                                                 Cmds),
+              ok = lev_cin_fsm:stop(?SERVER),
+              ?WHENFAIL(
+                 io:format("History: ~w~nState: ~w\nResult: ~w~n",
+                           [History, State, Result]),
+                 aggregate(zip(proper_fsm:state_names(History),
+                               command_names(Cmds)),
+                           Result =:= ok))
+          end)).
+
+%%%===================================================================
+%%% Callbacks
+%%%===================================================================
+
+initial_state() ->
+    importing.
+
+initial_state_data() ->
+    #state{cin_id = ?CIN_ID, host_id = ?HOST_ID, cen_ids = ?CEN_IDS}.
+
+importing(_S) ->
+    [
+     transition(pending, [?STATUS_CHANGE(pending)])
+    ].
+
+pending(_S) ->
+    [
+     transition(preparing, [?STATUS_CHANGE(preparing)])
+    ].
+
+preparing(_S) ->
+    [
+     transition(ready, [?STATUS_CHANGE(ready)])
+    ].
+
+ready(_S) ->
+    [
+     transition(destroying, [?STATUS_CHANGE(destroying)])
+    ].
+
+destroying(_S) ->
+    [
+     transition(pending, [?STATUS_CHANGE(pending)])
+    ].
+
+
+precondition(_From, _Target, _StateData, {call,_,_,_}) ->
+    true.
+
+postcondition(importing, pending, StateData, _Call, _Result) ->
+    #state{cin_id = CinId, host_id = HostId} = StateData,
+    subscriber_got_message({imported, {CinId, HostId}});
+postcondition(pending, preparing, StateData, _Call, _Result) ->
+    #state{cin_id = CinId, host_id = HostId} = StateData,
+    subscriber_got_message({prepared, {CinId, HostId}});
+postcondition(ready, destroying, StateData, _Call, _Result) ->
+    #state{cin_id = CinId, host_id = HostId} = StateData,
+    subscriber_got_message({destroyed, {CinId, HostId}});
+postcondition(From, Target, _, _, _) when From =/= Target ->
+    true.
+
+next_state_data(_From, _Target, StateData, _Result, _Call) ->
+    StateData.
+
+%%%===================================================================
+%%% Helpers
+%%%===================================================================
+
+setup() ->
+    teardown(),
+    mock(),
+    application:set_env(lager, handlers,
+                        [{lager_console_backend, error}]),
+    [{ok, _} = application:ensure_all_started(A) || A <- ?APPS],
+    publish_cin(),
+    {ok, _Pid} = proc_lib:start_link(?MODULE, subscriber, [self()]).
+    
+
+mock() ->
+    meck:new(leviathan_cin),
+    meck:expect(leviathan_cin, prepare, 1, ok),
+    meck:expect(leviathan_cin, destroy, 1, ok).
+
+publish_cin() ->
+    ok = dby:publish(
+           <<"publisher">>,
+           {leviathan_dby:dby_cin_id(?CIN_ID),
+            [
+             {<<"type">>, <<"cin">>},
+             {<<"status">>, <<"importing">>}
+            ]},
+           [persistent]).
+
+
+teardown() ->
+    meck:unload(),
+    catch dby_db:clear(),
+    case catch (?SUBSCRIBER ! {stop, self()}) of
+        {'EXIT', _} ->
+            ok;
+        _ ->
+            receive stopped -> ok end
+    end,
+    [application:stop(A) || A <- lists:reverse(?APPS)].
+
+
+transition(NextState, Args) ->
+    {NextState, ?CALL(Args)}.
+
+
+subscriber(Parent) ->
+    register(?SUBSCRIBER, Me = self()),
+    Fn = fun(Msg) -> Me ! {lev_msg, Msg} end,
+    SubId = leviathan_dby:subscribe_for_cin_message(?CIN_ID, Fn),
+    proc_lib:init_ack(Parent, {ok, self()}),
+    subscriber_loop(fun(Pid) ->
+                            leviathan_dby:unsubscribe(SubId),
+                            Pid ! stopped
+                    end).
+
+subscriber_loop(OnStop) ->
+    receive
+        {ex_msg, Pid, Ref, ExpectedMessage} ->
+            receive {lev_msg, ExpectedMessage} -> Pid ! {ok, Ref} end,
+            subscriber_loop(OnStop);
+        {stop, Pid} ->
+            OnStop(Pid)
+    end.
+
+subscriber_got_message(ExpectedMessage) ->
+    ?SUBSCRIBER ! {ex_msg, self(), Ref = make_ref(), ExpectedMessage},
+    receive {ok, Ref} -> true
+    after 5000 -> false end.


### PR DESCRIPTION
The lev_executive module is the entry point to the system. It is used
by the leviathan_rest as a callback module for handling requests.

The FSMs are spawned per a CEN/CIN and a host, that particular CEN/CIN
spans over. They react on the status changes in Dobby identifiers tied
to the CENs and CINs.

The CEN/CIN LMs are distributed over the cluster by Distributed Erlang.
Each Erlang nodes manages its authoritative store, which currently has
the same content on each node.
